### PR TITLE
Use `communicate()` instead of `wait()`

### DIFF
--- a/mup/proc/command_runner.py
+++ b/mup/proc/command_runner.py
@@ -79,11 +79,10 @@ class CommandRunner(object):
         logger.debug("Command environment %s", str(env))
         logger.debug("Command working directory %s", subprocess_args['cwd'])
         proc = subprocess.Popen(command, **subprocess_args)
-        result = proc.wait()
+        stdout, stderr = proc.communicate()
+        result = proc.returncode
 
         if silent:
-            stdout = proc.stdout.read()
-            stderr = proc.stderr.read()
             proc.stdout.close()
             proc.stderr.close()
             return CommandResult(result, stdout, stderr)


### PR DESCRIPTION
Avoids the deadlock possibility. See first note: https://docs.python.org/3/library/subprocess.html#subprocess.Popen.wait